### PR TITLE
Address validator

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -169,7 +169,11 @@ export const getter_args_to_mich = (arg: Micheline, callback: Entrypoint): Miche
 export class Address implements ArchetypeType {
   private _content: string
   constructor(v: string) {
-    this._content = v
+    
+    // this._content = v
+
+    this._content = this.validate_address(v)
+  
     /* TODO check address format */
   }
   to_mich(): Micheline {
@@ -181,6 +185,22 @@ export class Address implements ArchetypeType {
   toString(): string {
     return this._content
   }
+
+    private validate_address(input: string) {
+      let valid_address = false
+      const regexp = new RegExp(/(tz1|KT1)[A-Za-z0-9]{33}/)
+      const address_match = input.match(regexp)
+      if (address_match !== null) 
+        valid_address = address_match[0] === input 
+      if (valid_address) {
+        return input
+      } else { 
+        throw new Error(`Invalid address input. Recieved input: ${input}`)
+      }
+    }
+      // (tz1|KT1)[A-Za-z0-9]{33}
+    // }
+
 }
 
 export class Bls12_381_fr implements ArchetypeType {

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,13 +169,8 @@ export const getter_args_to_mich = (arg: Micheline, callback: Entrypoint): Miche
 export class Address implements ArchetypeType {
   private _content: string
   constructor(v: string) {
-    
-    // this._content = v
-
     this._content = this.validate_address(v)
-  
-    /* TODO check address format */
-  }
+    }
   to_mich(): Micheline {
     return string_to_mich(this._content)
   }
@@ -198,8 +193,6 @@ export class Address implements ArchetypeType {
         throw new Error(`Invalid address input. Recieved input: ${input}`)
       }
     }
-      // (tz1|KT1)[A-Za-z0-9]{33}
-    // }
 
 }
 

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -196,3 +196,53 @@ describe('ArchetypeType', () => {
 
   })
 })
+
+
+describe('Address', () => {
+
+  test('Succeeds with Valid User Address', () => {
+    const input = "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"
+    expect(new Address(input).toString()).toBe(input)
+  })
+
+  test('Succeeds with Valid Contract Address', () => {
+    const input = "KT1AaaBSo5AE6Eo9fpEN5xhCD4w3kHStafxk"
+    expect(new Address(input).toString()).toBe(input)
+  })
+
+  test('Fails with invalid character', () => {
+    const input = "tz1VSUr8ww!hLAzempoch5d6hLRiTh8Cjcjb"
+    expect(() => { new Address(input) }).toThrow(`Invalid address input. Recieved input: ${input}`)
+  })
+
+  test('Fails if address too long', () => {
+    const input = "tz1VSUr8wwzhLAzempoch5d6hLRiTh8Cjcjbsaf"
+    expect(() => { new Address(input) }).toThrow(`Invalid address input. Recieved input: ${input}`)
+  })
+
+  test('Fails if address too short', () => {
+    const input = "KT1VSUr8wwzhLAzemp"
+    expect(() => { new Address(input) }).toThrow(`Invalid address input. Recieved input: ${input}`)
+  })
+
+  test('Fails with empty string', () => {
+    const input = ""
+    expect(() => { new Address(input) }).toThrow(`Invalid address input. Recieved input: ${input}`)
+  })
+
+  test('Fails with dummy string', () => {
+    const input = "dummy"
+    expect(() => { new Address(input) }).toThrow(`Invalid address input. Recieved input: ${input}`)
+  })
+
+  test('Fails without contract type prefix', () => {
+    const input = "VSUr8wwzhLAzempoch5d6hLRiTh8Cjcjbsaf"
+    expect(() => { new Address(input) }).toThrow(`Invalid address input. Recieved input: ${input}`)
+  })
+
+  test('Fails with prefix only', () => {
+    const input = "tz1"
+    expect(() => { new Address(input) }).toThrow(`Invalid address input. Recieved input: ${input}`)
+  })
+
+})


### PR DESCRIPTION
I have assumed that addresses must begin with either tz1 and KT1 followed by exactly 33 alphanumeric characters. I could not find a specification to confirm if this is always true.