### PR TITLE
Add positive validation for duration

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -388,6 +388,9 @@ export class Duration implements ArchetypeType {
     's': 1
   }
   private is_duration_valid(input: string) {
+    const pos_regexp = new RegExp(/(\d+[wdhms]){1,5}/)
+    const pos_valid = input.match(pos_regexp)
+    if (pos_valid && pos_valid[0] !== input) return false 
     return Object.keys(this.DURATION_CONVERSION).reduce((acc, key) => {
       const regexp = new RegExp(`\\d+${key}`);
       const ritem_value = input.match(regexp)

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -102,6 +102,16 @@ describe('Chain_id', () => {
       expect(() => { new Duration("0") }).toThrow("Invalid duration input. Received input: `0' Try this format: '_w_d_h_m_s'.")
     });
 
+    test('Fails with typo in unit letter', () => {
+      const input = "3g8d4h34m18s"
+      expect(() => { new Duration(input) }).toThrow("Invalid duration input. Received input: `" + input + "' Try this format: '_w_d_h_m_s'.")
+    });
+
+    test('Fails with typo in unit letter', () => {
+      const input = "3w8d4h34m18a"
+      expect(() => { new Duration(input) }).toThrow("Invalid duration input. Received input: `" + input + "' Try this format: '_w_d_h_m_s'.")
+    });
+
     it('Simple test', () => {
       expect(new Duration("0s").toSecond()).toBe(0)
     })
@@ -124,6 +134,10 @@ describe('Chain_id', () => {
 
     it('1 week test', () => {
       expect(new Duration("1w").toSecond()).toBe(604800)
+    })
+
+    it('1 week, 1 second test', () => {
+      expect(new Duration("1w1s").toSecond()).toBe(604801)
     })
 
     it('1 week, 1 day, 1 hour, 1 minute, 1 second test', () => {


### PR DESCRIPTION
Positive validation for duration.

I noticed that if you mistype one of the units sent to duration constructor it doesn't fail.

For example, if you mean to write "1m20s" but you accidentally type "1m20a" it will not fail, and the output will be 60 instead of 80.

With this change it will fail with invalid duration error message