### PR TITLE
propose minor changes to tez type

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -917,8 +917,8 @@ export class Tez implements ArchetypeType {
           throw new Error("Mutez value must be integer");
         break
       case "tez":
-        if (this._content.isLessThan(new BigNumber(0)) || this._content.isGreaterThan(new BigNumber("")))
-          throw new Error("Invalid Tez value")
+        if (this._content.isLessThan(new BigNumber(0))) throw new Error("Tez value must not be negative")
+        if (this._content.isGreaterThan(new BigNumber("")) || this._content.isNaN()) throw new Error("Invalid Tez value")
         this._content = new BigNumber(this._content.times(1000000).integerValue(BigNumber.ROUND_FLOOR))
     }
   }
@@ -934,13 +934,17 @@ export class Tez implements ArchetypeType {
   plus(x: Tez): Tez {
     return new Tez(this._content.plus(x.to_big_number()), "mutez")
   }
+  minus(x: Tez): Tez {
+    return new Tez(this._content.minus(x.to_big_number()), "mutez")
+  }
   times(x: Nat): Tez {
     return new Tez(this._content.times(x.to_big_number()), "mutez")
   }
   equals = (x: Tez): boolean => {
     return this._content.isEqualTo(x.to_big_number())
   }
-  toString = (): string => {
+  toString = (unit: "tez" | "mutez" = "mutez"): string => {
+    if (unit == "tez") return this._content.div(1000000).toFixed()
     return this._content.toFixed()
   }
 }

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import { Address, Chain_id, Duration, Key, Micheline, Mstring, Nat, Rational, Signature, Ticket, Key_hash, micheline_equals, UnsafeMicheline, replace_var } from '../src/main'
+import { Address, Chain_id, Duration, Key, Micheline, Mstring, Nat, Rational, Signature, Ticket, Key_hash, micheline_equals, UnsafeMicheline, replace_var, Tez } from '../src/main'
 
 describe('Micheline', () => {
   test('int int true', () => {
@@ -357,6 +357,55 @@ describe('ArchetypeType', () => {
     });
 
   })
+
+  describe('Tez', () => {
+
+    test('Fails with empty string', () => {
+      const input = ""
+      expect(() => { new Tez(input) }).toThrow("Invalid Tez value")
+    })
+
+    test('Fails with text string', () => {
+      const input = "abc"
+      expect(() => { new Tez(input) }).toThrow("Invalid Tez value")
+    })
+
+    test('Succeeds with numerical string ', () => {
+      const input = "123"
+      expect(new Tez(input).toString()).toEqual("123000000")
+    })
+    
+    describe('toString', () => {
+      test('Succeeds with numerical string ', () => {
+        const input = "123"
+        expect(new Tez(input).toString("tez")).toEqual("123")
+      })
+    })  
+
+    test('Succeeds with numerical string ', () => {
+      const input = "123123123"
+      expect(new Tez(input, "mutez").toString("tez")).toEqual("123.123123")
+      console.log(new Tez(input, "mutez").toString("tez"))
+    })
+
+    describe('Minus', () => {
+      test('Succeeds with positive result', () => {
+        const minuend = 10
+        const subtrahend = 9
+        const difference = minuend-subtrahend
+        expect(new Tez(minuend).minus(new Tez(subtrahend)).equals(new Tez(difference))).toBe(true)
+      })
+
+      test('Fails with negative result', () => {
+        const minuend = 10
+        const subtrahend = 11
+        const difference = minuend-subtrahend
+        expect(() => {new Tez(minuend).minus(new Tez(subtrahend)).equals(new Tez(difference))}).toThrow("Tez value must not be negative")
+      })
+
+    })
+
+  });
 
   describe('Signature', () => {
     test('Fails with empty string', () => {


### PR DESCRIPTION
Three changes:

1. Introduce new error message "Tez value must not be negative" (I could make edits leave this as "invalid tez value")
2. Check if bignumber is NAN so that "invalid tez value" is thrown for inputs such as empty string, non-numerical text etc (currently this results in a bignumber object containing keys with null values)
3. Include minus method on Tez, as discussed on slack. Negative values return error from point 1.

Also added some basic tests on the Tez type.